### PR TITLE
feat: bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
         "upgrade": "npx sort-package-json && ncu -u"
     },
     "dependencies": {
-        "stylelint-config-standard": "^20.0.0",
-        "stylelint-order": "^4.1.0"
+        "stylelint-config-standard": "^24.0.0",
+        "stylelint-order": "^5.0.0"
     },
     "devDependencies": {
         "npm-check-updates": "^10.2.5",
-        "prettier": "^2.2.1",
+        "prettier": "^2.5.0",
         "prettier-config-hive": "^0.1.7",
-        "sort-package-json": "^1.48.0"
+        "sort-package-json": "^1.53.1"
     }
 }


### PR DESCRIPTION
Relate to https://github.com/ripe-tech/ripe-white/issues/935 and https://github.com/ripe-tech/ripe-white/pull/936

`eslint-config-recommended` updated to support `eslintv8` and this requires those changes: https://github.com/stylelint/stylelint-config-recommended/releases/tag/6.0.0